### PR TITLE
ci: add workflow to show available github env vars

### DIFF
--- a/.github/workflows/actions_vars.yml
+++ b/.github/workflows/actions_vars.yml
@@ -1,0 +1,14 @@
+---
+name: GitHub Actions Environment Variables
+
+on:
+  workflow_dispatch
+
+jobs:
+  Variables:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump github variable
+        env:
+          GITHUB_VAR: ${{ toJson(github) }}
+        run: echo "$GITHUB_VAR"


### PR DESCRIPTION
Adds the option to run a workflow called `actions_vars.yml` on any branch to display existing GitHub actions environment variables.