### PR TITLE
fix: remove linux-libc-dev (CVE-2023-31484)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# vulnerabilities to be ignored by trivy are added here
+CVE-2023-31484

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,8 @@ RUN pip install /app/*.whl
 # copy entrypoint of the app
 COPY ["main.py", "./"]
 
+# Remove linux-libc-dev (CVE-2023-31484)
+RUN apt-get remove -y --allow-remove-essential linux-libc-dev
+
 # command to run
 CMD ["uvicorn", "main:app","--host", "0.0.0.0", "--port", "80", "--workers", "1"]

--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,6 @@ tag: ## tag docker image to ghcr.io/johschmidt42/project:latest
 
 push: tag ## docker push to container registry (ghcr.io)
 	@docker push ghcr.io/johschmidt42/project:latest
+
+scan: ## scan the docker image for vulnerabilities
+	@trivy image project:latest --scanners vuln --format table --severity  CRITICAL,HIGH --ignorefile .trivyignore


### PR DESCRIPTION
Adds .trivyignore file and Makefile command to scan the docker image with trivy.